### PR TITLE
Fix missing cfc as profile in nextflow.config

### DIFF
--- a/conf/cfc.config
+++ b/conf/cfc.config
@@ -9,6 +9,10 @@
 *To be improved by process specific configuration asap, once our CFC cluster has the extra options removed - till then, task.attempt in NextFlow is not supported there.
 */
 
+singularity {
+    enabled = true
+}
+
 process {
     beforeScript = 'module load qbic/singularity_slurm/2.5.2'
     executor = 'slurm'

--- a/nextflow.config
+++ b/nextflow.config
@@ -46,6 +46,9 @@ profiles {
     includeConfig 'conf/aws.config'
     includeConfig 'conf/igenomes.config'
   }
+  cfc {
+    includeConfig 'conf/cfc.config'
+  }
   full_trace {
     includeConfig 'conf/full_trace.config'
   }


### PR DESCRIPTION
This should fix the issue that cfc profile is missing - should work now. please wait for tests to run through before merging that one :-) 
