### PR TITLE
add params_description space to nextflow.config

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -12,7 +12,6 @@
 params {
 
   container = 'nfcore/hlatyping:1.1.4' // Container slug. Stable releases should specify release tag!
-
   help = false
   outdir = './results'
   bam = false

--- a/nextflow.config
+++ b/nextflow.config
@@ -12,7 +12,7 @@
 params {
 
   container = 'nfcore/hlatyping:1.1.4' // Container slug. Stable releases should specify release tag!
-  
+
   help = false
   outdir = './results'
   bam = false
@@ -36,6 +36,11 @@ params {
   custom_config_version = 'master'
   custom_config_base = "https://raw.githubusercontent.com/nf-core/configs/${params.custom_config_version}"
 
+}
+
+// Specify params.settings.json settings
+params_description {
+	path = "$baseDir/parameters.settings.json"
 }
 
 // Load base.config by default for all pipelines


### PR DESCRIPTION
Introduce `params_description` space to the config.
Add default location. 