### PR TITLE
Mini Patch Branch Test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ matrix:
 
 before_install:
   # PRs to master are only ok if coming from dev branch
-  - '[ $TRAVIS_PULL_REQUEST = "false" ] || [ $TRAVIS_BRANCH != "master" ] || ([ $TRAVIS_PULL_REQUEST_SLUG = $TRAVIS_REPO_SLUG ] && [ $TRAVIS_PULL_REQUEST_BRANCH = "dev" ])'
+  - '[ $TRAVIS_PULL_REQUEST = "false" ] || [ $TRAVIS_BRANCH != "master" ] || ([ $TRAVIS_PULL_REQUEST_SLUG = $TRAVIS_REPO_SLUG ] && ([ $TRAVIS_PULL_REQUEST_BRANCH = "dev" ] || [ $TRAVIS_PULL_REQUEST_BRANCH = "patch" ]))'
   # Pull the docker image first so the test doesn't wait for this
   - docker pull nfcore/hlatyping:dev
   # Fake the tag locally so that the pipeline runs properly


### PR DESCRIPTION
This is solely a test to figure out whether we can get TravisCI to allow a branch from `dev` and `patch` to consider for testing to `dev`. 

Can then be used e.g. here:

https://github.com/nf-core/tools/pull/388


## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [x] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] If necessary, also make a PR on the [nf-core/hlatyping branch on the nf-core/test-datasets repo]( https://github.com/nf-core/test-datasets/pull/new/nf-core/hlatyping)
 - [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
 - [ ] Make sure your code lints (`nf-core lint .`).
 - [ ] Documentation in `docs` is updated
 - [ ] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated

**Learn more about contributing:** https://github.com/nf-core/hlatyping/tree/master/.github/CONTRIBUTING.md
