### PR TITLE
Add OptiType results to MultiQC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Added`
 
+- [#141](https://github.com/nf-core/hlatyping/pull/141) - Add `OptiType` results to `MultiQC` report
+
 ### `Changed`
 
 - [#140](https://github.com/nf-core/hlatyping/pull/140) - Port pipeline to `DSL2`

--- a/assets/multiqc_optitype_config.yml
+++ b/assets/multiqc_optitype_config.yml
@@ -1,0 +1,2 @@
+table_columns_visible:
+  OptiType: True

--- a/nextflow.config
+++ b/nextflow.config
@@ -23,7 +23,7 @@ params {
     igenomes_ignore            = false
 
     // MultiQC options
-    multiqc_config             = null
+    multiqc_config             = "$projectDir/assets/multiqc_optitype_config.yml"
     multiqc_title              = null
     multiqc_logo               = "${projectDir}/assets/nf-core-hlatyping_logo_light.png"
     max_multiqc_email_size     = '25.MB'

--- a/workflows/hlatyping.nf
+++ b/workflows/hlatyping.nf
@@ -192,6 +192,7 @@ workflow HLATYPING {
         ch_versions.unique().collectFile(name: 'collated_versions.yml')
     )
 
+
     //
     // MODULE: MultiQC
     //
@@ -206,12 +207,13 @@ workflow HLATYPING {
     ch_multiqc_files = ch_multiqc_files.mix(ch_methods_description.collectFile(name: 'methods_description_mqc.yaml'))
     ch_multiqc_files = ch_multiqc_files.mix(CUSTOM_DUMPSOFTWAREVERSIONS.out.mqc_yml.collect())
     ch_multiqc_files = ch_multiqc_files.mix(FASTQC.out.zip.collect{it[1]}.ifEmpty([]))
+    ch_multiqc_files = ch_multiqc_files.mix(OPTITYPE.out.output.collect{it[1]}.ifEmpty([]))
 
     MULTIQC (
         ch_multiqc_files.collect(),
         ch_multiqc_config.collect().ifEmpty([]),
         ch_multiqc_custom_config.collect().ifEmpty([]),
-        ch_multiqc_logo.collect().ifEmpty([])
+        ch_multiqc_logo.collect().ifEmpty([]),
     )
     multiqc_report = MULTIQC.out.report.toList()
     ch_versions    = ch_versions.mix(MULTIQC.out.versions)


### PR DESCRIPTION
This
- adds the OptiType results to MultiQC (visualized by MultiQC OptiType module)
- shows all OptiType columns by default.

Resolves #105.

<!--
# nf-core/hlatyping pull request

Many thanks for contributing to nf-core/hlatyping!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/hlatyping/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
- [ ] If necessary, also make a PR on the [nf-core/hlatyping branch on the nf-core/test-datasets repo](https://github.com/nf-core/test-datasets/pull/new/nf-core/hlatyping)
