### PR TITLE
Add missing --enumerate arg.

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -48,6 +48,7 @@ process {
                 mode: params.publish_dir_mode,
                 saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
             ]
+        ext.args = "--enumerate ${params.enumerations}"
         ext.args2 = "solver=${params.solver}"
     }
 


### PR DESCRIPTION
<!--
# nf-core/hlatyping pull request

Many thanks for contributing to nf-core/hlatyping!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/hlatyping/tree/master/.github/CONTRIBUTING.md)
-->

## Description
[`params.enumerations`](https://github.com/nf-core/hlatyping/blob/7c9a2fbd404fae653d12e14db823b378512fbb40/nextflow.config#L17) is not supplied to the `OPTITYPE` process through [`modules.config`](https://github.com/nf-core/hlatyping/blob/7c9a2fbd404fae653d12e14db823b378512fbb40/conf/modules.config#L53-L60) therefore the parameter doesn't affect the output.

The quick solution is to add the parameter to `ext.args`, which works as tested with the test profile. Long-term though it would probably be best to refactor the optitype module code to take an input dictionary, like how the [`controlfreec`](https://github.com/nf-core/modules/blob/6258d8bfef0787df4a10ac84e58f52b6f3deb847/modules/nf-core/controlfreec/freec/main.nf#L39-L66) module does it. This would allow finer control over optitypes' `config.ini`. But that is a PR for another time 😊

There are some pre-existing linting issues with the templates but that's probably best fixed in a separate PR.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/hlatyping/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/hlatyping _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
