### PR TITLE
Fix conda tests by pinning pytables<3.10

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -27,7 +27,7 @@
                     },
                     "optitype": {
                         "branch": "master",
-                        "git_sha": "41dfa3f7c0ffabb96a6a813fe321c6d1cc5b6e46",
+                        "git_sha": "c4b4c8ef7b233740544d51566185d9c66bdc27aa",
                         "installed_by": ["modules"]
                     },
                     "samtools/collatefastq": {

--- a/modules/nf-core/optitype/environment.yml
+++ b/modules/nf-core/optitype/environment.yml
@@ -6,3 +6,6 @@ channels:
 dependencies:
   - bioconda::optitype=1.3.5
   - conda-forge::coincbc=2.10.10
+  # Pin pytables<3.10 to avoid Python 3.13 compatibility issues with OptiType's HDF5 files
+  # See: https://github.com/nf-core/hlatyping/pull/206
+  - pytables<3.10

--- a/modules/nf-core/optitype/environment.yml
+++ b/modules/nf-core/optitype/environment.yml
@@ -7,5 +7,4 @@ dependencies:
   - bioconda::optitype=1.3.5
   - conda-forge::coincbc=2.10.10
   # Pin pytables<3.10 to avoid Python 3.13 compatibility issues with OptiType's HDF5 files
-  # See: https://github.com/nf-core/hlatyping/pull/206
-  - conda-forge::pytables<3.10
+  - conda-forge::pytables=3.9.2

--- a/modules/nf-core/optitype/environment.yml
+++ b/modules/nf-core/optitype/environment.yml
@@ -8,4 +8,4 @@ dependencies:
   - conda-forge::coincbc=2.10.10
   # Pin pytables<3.10 to avoid Python 3.13 compatibility issues with OptiType's HDF5 files
   # See: https://github.com/nf-core/hlatyping/pull/206
-  - pytables<3.10
+  - conda-forge::pytables<3.10


### PR DESCRIPTION
## Summary

- Pin `pytables<3.10` in optitype environment.yml to fix conda test failures

## Problem

OptiType 1.3.5 (last updated September 2020) is incompatible with Python 3.13 and pytables>=3.10. When conda resolves dependencies, it pulls Python 3.13 + latest pytables, which has stricter byte/string type handling that breaks OptiType's HDF5 allele files.

The error manifests as:
```
TypeError: a bytes-like object is required, not 'str'
  at pandas/io/pytables.py line 1866 in _create_storer
```

This was observed in PR #206 where `conda | 25.04.2` jobs failed while Docker/Singularity passed (containers have pinned older dependencies).

## Solution

Pin `pytables<3.10` to maintain compatibility until OptiType upstream addresses Python 3.13 support (unlikely given the project hasn't been updated since 2020).

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [x] Make sure your code lints (`nf-core pipelines lint`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)