### PR TITLE
Bump nf-schema plugin to 2.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#211](https://github.com/nf-core/hlatyping/pull/211) - Clean up published output by disabling publishing for intermediate processes (CHECK_PAIRED, YARA_INDEX, YARA_MAPPER, SAMTOOLS_VIEW, SAMTOOLS_COLLATEFASTQ, HLAHD_INSTALL, WGET, UNTAR, HLALA_PREPAREGRAPH) (@jonasscheid)
 - [#218](https://github.com/nf-core/hlatyping/pull/218) - Merge nf-core template updates up to `4.0.2` (@jonasscheid)
 - [#221](https://github.com/nf-core/hlatyping/pull/221) - Update the metro map overview diagram to include HLA\*LA, SpecHLA, immunotype (TSV input) and the summary step, with animated lines, regenerated using nf-metro 0.7.2 (@jonasscheid)
+- [#223](https://github.com/nf-core/hlatyping/pull/223) - Bump `nf-schema` plugin to 2.7.2 (@jonasscheid)
 
 ### `Fixed`
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -335,7 +335,7 @@ manifest {
 
 // Nextflow plugins
 plugins {
-    id 'nf-schema@2.5.1' // Validation of pipeline parameters and creation of an input channel from a sample sheet
+    id 'nf-schema@2.7.2' // Validation of pipeline parameters and creation of an input channel from a sample sheet
 }
 
 validation {


### PR DESCRIPTION
## Description

Bumps the `nf-schema` Nextflow plugin from `2.5.1` to `2.7.2` (latest release) in `nextflow.config`.

This is a maintenance dependency bump only; there are no pipeline code or logic changes. The pipeline continues to use nf-schema for parameter validation and for building the input channel from the sample sheet. CI should confirm compatibility across the version range.

### Changes

- `nextflow.config`: `nf-schema@2.5.1` -> `nf-schema@2.7.2`
- `CHANGELOG.md`: added an entry under the unreleased section