### PR TITLE
fix: typo update_dictionary.sh should be update.dictionary.sh

### DIFF
--- a/modules/local/hlahd/install/main.nf
+++ b/modules/local/hlahd/install/main.nf
@@ -38,7 +38,7 @@ process HLAHD_INSTALL {
 
     # UPDATE THE DICTIONARY IF REQUESTED
     if [ $update_dict_flag -eq 1 ]; then
-        sh update_dictionary.sh
+        sh update.dictionary.sh
     fi
 
     cd ../../


### PR DESCRIPTION
Hi Jonas,

I got the following error when trying to run `HLAHD_INSTALL` with `--hlahd_update_reference_dict`:

```sh
sh: 0: cannot open update_dictionary.sh: No such file
```

I checked the work folder and manually examined the HLA-HD tarball and found that the script name was actually `update.dictionary.sh` (I also confirmed my tarball hash matches yours in the script):

```bash
$ cd hlahd.1.7.1 && ls -1
/home/vajith/my_scratch/hlahd.1.7.1
bin
data
dictionary
estimation
freq_data
HLA_gene.split.3.32.0.txt
HLA_gene.split.3.50.0.txt
HLA_gene.split.txt
install.sh
Readme.txt
src
update.dictionary.sh
```

When I fixed the typo in the work folder the process found the path correctly.